### PR TITLE
fix: form field Enum overrides

### DIFF
--- a/src/python-fastui/fastui/json_schema.py
+++ b/src/python-fastui/fastui/json_schema.py
@@ -320,6 +320,7 @@ def deference_json_schema(
         if def_schema is None:
             raise ValueError(f'Invalid $ref "{ref}", not found in {defs}')
         else:
+            def_schema.update({k: v for k, v in schema.items() if k != '$ref'})  # type: ignore
             return def_schema, required
     elif any_of := schema.get('anyOf'):
         if len(any_of) == 2 and sum(s.get('type') == 'null' for s in any_of) == 1:

--- a/src/python-fastui/tests/test_forms.py
+++ b/src/python-fastui/tests/test_forms.py
@@ -517,7 +517,7 @@ class ToolEnum(str, Enum):
 
 class FormEnumWithOptionalEnum(BaseModel):
     job_name: str
-    tool_required: ToolEnum | None = Field(
+    tool_required: Union[ToolEnum, None] = Field(
         json_schema_extra={
             # Override certain schema fields.
             'placeholder': 'tool',

--- a/src/python-fastui/tests/test_forms.py
+++ b/src/python-fastui/tests/test_forms.py
@@ -1,4 +1,5 @@
 from contextlib import asynccontextmanager
+from enum import Enum
 from io import BytesIO
 from typing import List, Tuple, Union
 
@@ -6,7 +7,7 @@ import pytest
 from fastapi import HTTPException
 from fastui import components
 from fastui.forms import FormFile, Textarea, fastui_form
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from starlette.datastructures import FormData, Headers, UploadFile
 from typing_extensions import Annotated
 
@@ -500,6 +501,62 @@ def test_form_numbers_default_step():
                 'htmlType': 'number',
                 'step': 'any',
                 'type': 'FormFieldInput',
+            },
+        ],
+    }
+
+
+class ToolEnum(str, Enum):
+    """Tools that can be leveraged to complete a job."""
+
+    hammer = 'hammer'
+    screwdriver = 'screwdriver'
+    saw = 'saw'
+    claw_hammer = 'claw_hammer'
+
+
+class FormEnumWithOptionalEnum(BaseModel):
+    job_name: str
+    tool_required: ToolEnum | None = Field(
+        json_schema_extra={
+            # Override certain schema fields.
+            'placeholder': 'tool',
+            'description': '',
+        }
+    )
+
+
+def test_form_with_enum():
+    m = components.ModelForm(model=FormEnumWithOptionalEnum, submit_url='/foobar')
+
+    assert m.model_dump(by_alias=True, exclude_none=True) == {
+        'submitUrl': '/foobar',
+        'method': 'POST',
+        'type': 'ModelForm',
+        'formFields': [
+            {
+                'name': 'job_name',
+                'title': ['Job Name'],
+                'required': True,
+                'locked': False,
+                'htmlType': 'text',
+                'type': 'FormFieldInput',
+            },
+            {
+                'name': 'tool_required',
+                'title': ['ToolEnum'],
+                'required': False,
+                'locked': False,
+                'description': '',
+                'options': [
+                    {'value': 'hammer', 'label': 'Hammer'},
+                    {'value': 'screwdriver', 'label': 'Screwdriver'},
+                    {'value': 'saw', 'label': 'Saw'},
+                    {'value': 'claw_hammer', 'label': 'Claw Hammer'},
+                ],
+                'multiple': False,
+                'placeholder': 'tool',
+                'type': 'FormFieldSelect',
             },
         ],
     }


### PR DESCRIPTION
I noticed when using an optional `FormFieldSelect`, the default description and placeholder would override the ones I passed to the `json_schema_extra`.

Fixed using a similar strategy to what we already do a few lines below in https://github.com/pydantic/FastUI/blob/196414360b69b3dab7012576f852229831307883/src/python-fastui/fastui/json_schema.py#L334